### PR TITLE
Issue #243: Compiler Error when using mgwt.themebase and CustomTheme

### DIFF
--- a/src/main/java/com/googlecode/mgwt/theme/client/DialogPanelCustomAppearance.java
+++ b/src/main/java/com/googlecode/mgwt/theme/client/DialogPanelCustomAppearance.java
@@ -29,7 +29,7 @@ public class DialogPanelCustomAppearance extends DialogPanelAbstractAppearance {
     @Source({"com/googlecode/mgwt/ui/client/widget/dialog/panel/dialog.css", "css/dialog.css"})
     CssDialog cssPanel();
 
-    @Source({"com/googlecode/mgwt/ui/client/widget/dialog/overlay/dialog-overlay.css", "css/dialog.css"})
+    @Source({"com/googlecode/mgwt/ui/client/widget/dialog/overlay/dialog-overlay.css", "css/dialog-overlay.css"})
     OverlayCss overlay();
   }
 


### PR DESCRIPTION
fixed DialogPanelCustomAppearance: was referencing the wrong css file (dialog.css -> dialog-overlay.css)